### PR TITLE
Update to React 16.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "license": "ISC",
   "dependencies": {},
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^16.2.0"
   }
 }


### PR DESCRIPTION
This just bumps the version to React 16.2.0, fixing this message:
```
warning "nt-transmit-transparently@1.0.7" has incorrect peer dependency "react@^0.14.0 || ^15.0.0".
```

All works the same as before.

Fixes https://github.com/next-component/common-transmit-transparently/issues/1